### PR TITLE
FIX: escape linked page titles in user template

### DIFF
--- a/all_devices.template
+++ b/all_devices.template
@@ -51,7 +51,6 @@ Make notes on each device in its corresponding "Notes" section.
             <tr>
                 <th>Name</th>
                 <th>Class</th>
-                <th>Notes</th>
                 <th>Z</th>
             </tr>
         </thead>
@@ -66,15 +65,8 @@ Make notes on each device in its corresponding "Notes" section.
             </td>
             <td>
     {% if "class.template" in info %}
-              <ac:link>
-                <ri:page ri:content-title="{{ info["class.template"]["title"] }} "/>
-              </ac:link>
+              {{ info["class.template"]["title"] }}
     {% endif %}
-            </td>
-            <td>
-              <ac:link>
-                <ri:page ri:content-title="{{ info["user.template"]["title"] }} "/>
-              </ac:link>
             </td>
             <td>
                 {{ info.happi_item.z }}

--- a/generate.py
+++ b/generate.py
@@ -22,7 +22,7 @@ logging.basicConfig(level="INFO")
 logger = logging.getLogger(__name__)
 logger.setLevel("DEBUG")
 
-production = False
+production = True
 
 if production:
     SPACE = "PCDS"
@@ -519,13 +519,20 @@ def render_pages(
                     # that automatically
                     parent_id = client.get_parent_content_id(parent_id)
 
-                page_info = client.update_or_create(
-                    parent_id=parent_id,
-                    title=title,
-                    body=new_source,
-                    minor_edit=minor_edit,
-                    version_comment="happi-to-confluence update",
-                )
+                try:
+                    page_info = client.update_or_create(
+                        parent_id=parent_id,
+                        title=title,
+                        body=new_source,
+                        minor_edit=minor_edit,
+                        version_comment="happi-to-confluence update",
+                    )
+                except Exception as ex:
+                    logger.error("Failed to update page: %s", ex, exc_info=True)
+                    with open(f"failed_update_{title}.txt", "wt") as fp:
+                        fp.write(new_source)
+
+                    continue
 
         for label in page_template.labels:
             client.set_page_label(page_info["id"], label)

--- a/user.template
+++ b/user.template
@@ -7,11 +7,11 @@
 </p>
 
 {% for page in related_pages %}
-    <h2>Confluence page: {{ page.content.title }}</h2>
+    <h2>Confluence page: {{ page.content.title | e }}</h2>
     <ac:structured-macro ac:name="include" ac:schema-version="1">
       <ac:parameter ac:name="">
         <ac:link>
-          <ri:page ri:space-key="{{ page.space }}" ri:content-title="{{ page.content.title }}"/>
+          <ri:page ri:space-key="{{ page.space }}" ri:content-title="{{ page.content.title | e }}"/>
         </ac:link>
       </ac:parameter>
     </ac:structured-macro>


### PR DESCRIPTION
## Context

Updates to the dreaded happi device pages on confluence; at least until we either remove them, replace them, or move them to another space...

## Fixes

* Linked page failed: https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=337052617 due to title `SmarAct "SmarPod" Hexapod`
* Escaping linked page titles
* Dumping out source on failure
* Attempting to continue where possible (writing the top-level device 'view' will still fail in the event of failure, however, but this happens at the end of the process)
* Reduce links in top-level "happi devices" page