### PR TITLE
REF: reworking docs according to feedback [LCLSPC-647]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,30 @@
-all: pages
+GENERATE_ARGS ?= --test
+
+all: prod-pages
+
+clean:
+	rm -f happi_info.json
+
+check:
+	if [[ -f happi_info.json && $$(stat --format="%s" happi_info.json ) -eq 0 ]]; then \
+		echo "Removing stale/invalid happi_info.json"; \
+		rm -f happi_info.json; \
+	fi \
 
 happi_info.json: /cds/group/pcds/pyps/apps/hutch-python/device_config/db.json
-	python -m whatrecord.plugins.happi > $@
+	python -m whatrecord.plugins.happi > ".${@}"
+	mv ".${@}" "$@"
 
-pages: happi_info.json
+prod-pages: check happi_info.json
 	/bin/bash -c " \
 		source confluence.sh && \
-			python generate.py \
+			ipython --pdb generate.py -- --production $(GENERATE_ARGS) \
 	"
 
-.PHONY: pages
+dev-pages: check happi_info.json
+	/bin/bash -c " \
+		source confluence.sh && \
+			ipython --pdb generate.py -- $(GENERATE_ARGS) \
+	"
+
+.PHONY: all clean check dev-pages

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GENERATE_ARGS ?= --test
+GENERATE_ARGS ?=
 
 all: prod-pages
 

--- a/all_devices.template
+++ b/all_devices.template
@@ -62,34 +62,35 @@ Make notes on each device in its corresponding "Notes" section.
         </thead>
         <tbody>
 {% for item_name, info in all_item_state.items() | sort%}
-{% if not item_name.startswith("_") %}
-        <tr>
-            <td>
-              <a href="/pages/viewpage.action?pageId={{ info["device.template"]["id"] }}">
-                {{ info["device.template"]["title"] }}
-              </a>
-
-              -
-
-              (
-              <a href="/pages/editpage.action?pageId={{ info["user.template"]["id"] }}">
-                Edit
-              </a>
-              )
-
-            </td>
-            <td>
-    {% if "class.template" in info %}
-            <a href="/pages/viewpage.action?pageId={{ info["class.template"]["id"] }}">
-              {{ info["class.template"]["title"] }}
+  {% if not item_name.startswith("_") %}
+      <tr>
+          <td>
+            {{ info["device.template"]["title"] }}
+            <a href="/pages/viewpage.action?pageId={{ info["device.template"]["id"] }}">
+              View
             </a>
-    {% endif %}
-            </td>
-            <td>
-                {{ info.happi_item.z }}
-            </td>
-        </tr>
-{% endif %}
+            /
+            <a href="/pages/editpage.action?pageId={{ info["user.template"]["id"] }}">
+              Edit
+            </a>
+          </td>
+          <td>
+  {% if "class.template" in info %}
+          {{ info["class.template"]["title"] }}
+          <a href="/pages/viewpage.action?pageId={{ info["class.template"]["id"] }}">
+            View
+          </a>
+          /
+          <a href="/pages/editpage.action?pageId={{ info["class.template"]["id"] }}">
+            Edit
+          </a>
+  {% endif %}
+          </td>
+          <td>
+              {{ info.happi_item.z }}
+          </td>
+      </tr>
+  {% endif %}
 {% endfor %}
         </tbody>
     </table>

--- a/all_devices.template
+++ b/all_devices.template
@@ -59,13 +59,15 @@ Make notes on each device in its corresponding "Notes" section.
 {% if not item_name.startswith("_") %}
         <tr>
             <td>
-              <ac:link>
-                <ri:page ri:content-title="{{ info["device.template"]["title"] }} "/>
-              </ac:link>
+              <a href="/pages/viewpage.action?pageId={{ info["device.template"]["id"] }}"</a>
+                {{ info["device.template"]["title"] }}
+              </a>
             </td>
             <td>
     {% if "class.template" in info %}
+            <a href="/pages/viewpage.action?pageId={{ info["class.template"]["id"] }}"</a>
               {{ info["class.template"]["title"] }}
+            </a>
     {% endif %}
             </td>
             <td>

--- a/all_devices.template
+++ b/all_devices.template
@@ -49,7 +49,7 @@ Make notes on each device in its corresponding "Notes" section.
     <table>
         <thead>
             <tr>
-                <th>Name</th>
+                <th>Device Name</th>
                 <th>Class</th>
                 <th>Z</th>
             </tr>
@@ -59,13 +59,22 @@ Make notes on each device in its corresponding "Notes" section.
 {% if not item_name.startswith("_") %}
         <tr>
             <td>
-              <a href="/pages/viewpage.action?pageId={{ info["device.template"]["id"] }}"</a>
+              <a href="/pages/viewpage.action?pageId={{ info["device.template"]["id"] }}">
                 {{ info["device.template"]["title"] }}
               </a>
+
+              -
+
+              (
+              <a href="/pages/editpage.action?pageId={{ info["user.template"]["id"] }}">
+                Edit
+              </a>
+              )
+
             </td>
             <td>
     {% if "class.template" in info %}
-            <a href="/pages/viewpage.action?pageId={{ info["class.template"]["id"] }}"</a>
+            <a href="/pages/viewpage.action?pageId={{ info["class.template"]["id"] }}">
               {{ info["class.template"]["title"] }}
             </a>
     {% endif %}

--- a/all_devices_by_hutch.template
+++ b/all_devices_by_hutch.template
@@ -1,4 +1,4 @@
-# title: {{ root_page }}
+# title: Happi Devices by Hutch
 # label: auto-generated
 
 <ac:structured-macro ac:name="html" ac:schema-version="1">
@@ -51,45 +51,50 @@ Make notes on each device in its corresponding "Notes" section.
   POC or reach out to #pcds-help on Slack.
 </p>
 
-<h2>Happi Devices</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Device Name</th>
-                <th>Class</th>
-                <th>Z</th>
-            </tr>
-        </thead>
-        <tbody>
-{% for item_name, info in all_item_state.items() | sort%}
-{% if not item_name.startswith("_") %}
-        <tr>
-            <td>
-              <a href="/pages/viewpage.action?pageId={{ info["device.template"]["id"] }}">
-                {{ info["device.template"]["title"] }}
-              </a>
+<h2>Hutches / Beamlines</h2>
 
-              -
+{% for beamline in all_item_state_by_beamline | sort %}
 
-              (
-              <a href="/pages/editpage.action?pageId={{ info["user.template"]["id"] }}">
-                Edit
-              </a>
-              )
+  <h3>{{ beamline }}</h3>
 
-            </td>
-            <td>
-    {% if "class.template" in info %}
-            <a href="/pages/viewpage.action?pageId={{ info["class.template"]["id"] }}">
-              {{ info["class.template"]["title"] }}
+  <table>
+      <thead>
+          <tr>
+              <th>Device Name</th>
+              <th>Class</th>
+              <th>Z</th>
+          </tr>
+      </thead>
+      <tbody>
+  {% for info in all_item_state_by_beamline[beamline] %}
+      <tr>
+          <td>
+            <a href="/pages/viewpage.action?pageId={{ info["device.template"]["id"] }}">
+              {{ info["device.template"]["title"] }}
             </a>
-    {% endif %}
-            </td>
-            <td>
-                {{ info.happi_item.z }}
-            </td>
-        </tr>
-{% endif %}
-{% endfor %}
+
+            -
+
+            (
+            <a href="/pages/editpage.action?pageId={{ info["user.template"]["id"] }}">
+              Edit
+            </a>
+            )
+
+          </td>
+          <td>
+  {% if "class.template" in info %}
+          <a href="/pages/viewpage.action?pageId={{ info["class.template"]["id"] }}">
+            {{ info["class.template"]["title"] }}
+          </a>
+  {% endif %}
+          </td>
+          <td>
+              {{ info.happi_item.z }}
+          </td>
+      </tr>
+    {% endfor %}
         </tbody>
     </table>
+
+{% endfor %}

--- a/all_devices_by_hutch.template
+++ b/all_devices_by_hutch.template
@@ -69,23 +69,24 @@ Make notes on each device in its corresponding "Notes" section.
   {% for info in all_item_state_by_beamline[beamline] %}
       <tr>
           <td>
+            {{ info["device.template"]["title"] }}
             <a href="/pages/viewpage.action?pageId={{ info["device.template"]["id"] }}">
-              {{ info["device.template"]["title"] }}
+              View
             </a>
-
-            -
-
-            (
+            /
             <a href="/pages/editpage.action?pageId={{ info["user.template"]["id"] }}">
               Edit
             </a>
-            )
-
           </td>
           <td>
   {% if "class.template" in info %}
+          {{ info["class.template"]["title"] }}
           <a href="/pages/viewpage.action?pageId={{ info["class.template"]["id"] }}">
-            {{ info["class.template"]["title"] }}
+            View
+          </a>
+          /
+          <a href="/pages/editpage.action?pageId={{ info["class.template"]["id"] }}">
+            Edit
           </a>
   {% endif %}
           </td>

--- a/class.template
+++ b/class.template
@@ -1,6 +1,7 @@
 # title: {{ device_class }}
 # title: {{ device_class }}{{ page_title_marker }}
 # label: auto-generated
+# label: no-overwrite
 
 <h4>All devices of the Python class {{device_class}}</h4>
 <p>

--- a/class.template
+++ b/class.template
@@ -2,13 +2,7 @@
 # title: {{ device_class }}{{ page_title_marker }}
 # label: auto-generated
 
-<h4>All {{device_class}} devices</h4>
-
-See also the
-<a href="https://pcdshub.github.io/pcdsdevices/master/search.html?q={{device_class}}" target="_blank">
-  pcdsdevices documentation
-</a>.
-
+<h4>All devices of the Python class {{device_class}}</h4>
 <p>
   <ac:structured-macro ac:name="children" ac:schema-version="2">
     <ac:parameter ac:name="all">true</ac:parameter>

--- a/class.template
+++ b/class.template
@@ -2,20 +2,12 @@
 # title: {{ device_class }}{{ page_title_marker }}
 # label: auto-generated
 
-<ac:structured-macro ac:name="info" ac:schema-version="1">
-  <ac:parameter ac:name="title">What is this?</ac:parameter>
-  <ac:rich-text-body>
-    <p>This page lists all happi database items of the same Python class <code>{{device_class}}</code>.</p>
-    <p>If you wish to add notes about a specific device, please edit its corresponding "<code>- Notes</code>" page.</p>
-    <p>Additional usage information about this class may be available on the
-      <a href="https://pcdshub.github.io/pcdsdevices/master/search.html?q={{device_class}}" target="_blank">
-        pcdsdevices documentation site.
-      </a>
-    </p>
-  </ac:rich-text-body>
-</ac:structured-macro>
+<h4>All {{device_class}} devices</h4>
 
-<h2>{{device_class}}</h2>
+See also the
+<a href="https://pcdshub.github.io/pcdsdevices/master/search.html?q={{device_class}}" target="_blank">
+  pcdsdevices documentation
+</a>.
 
 <p>
   <ac:structured-macro ac:name="children" ac:schema-version="2">
@@ -23,3 +15,9 @@
     <ac:parameter ac:name="sort">title</ac:parameter>
   </ac:structured-macro>
 </p>
+
+<h4>My notes about {{device_class}}</h4>
+
+<i>
+  This is a spot for you to put notes about {{ device_class }}.
+</i>

--- a/device.template
+++ b/device.template
@@ -33,8 +33,9 @@ for all instances.
       pcdsdevices documentation site.
     </a>
   </i>
-  <br/>
 </p>
+
+<br/>
 
 <div title="Python documentation string from pcdsdevices">
 {{ device_class_doc }}

--- a/device.template
+++ b/device.template
@@ -10,29 +10,82 @@ Please don't edit this page. This page is auto-generated and may be frequently
 overwritten - your changes will NOT persist.
 
 The Notes page linked below is your spot for notes about this device.
+You may also edit the class page {{ device_class }} to document information
+for all instances.
 
 ** WAIT! **
 
--->]]></ac:plain-text-body>
+-->]]>
+</ac:plain-text-body>
 </ac:structured-macro>
 
+<h1>Table of Contents</h1>
+<ac:structured-macro ac:name="toc" ac:schema-version="1">
+  <ac:parameter ac:name="minLevel">2</ac:parameter>
+  <ac:parameter ac:name="outline">true</ac:parameter>
+</ac:structured-macro>
+
+<h2>Information from the source code</h2>
+<p>
+  <i>
+  Additional usage information about this device may be available on the
+    <a href="https://pcdshub.github.io/pcdsdevices/master/search.html?q={{device_class}}" target="_blank">
+      pcdsdevices documentation site.
+    </a>
+  </i>
+  <br/>
+</p>
+
+<div title="Python documentation string from pcdsdevices">
 {{ device_class_doc }}
+</div>
+
+{% if "class.template" in item_state %}
+{% set class_template = item_state["class.template"] %}
+
+<h2>Notes from the class page</h2>
+<p>
+  →
+  Please
+  <a href="/pages/editpage.action?pageId={{ class_template["id"] }}">
+    <b>EDIT CLASS INFORMATION HERE</b>
+  </a>
+  ←
+</p>
+
 <p>
   <ac:structured-macro ac:name="include" ac:schema-version="1">
     <ac:parameter ac:name="">
       <ac:link>
-        <ri:page ri:content-title="{{ page_title_prefix }}{{ device_name }}{{ user_page_suffix }}"/>
+        <ri:page ri:content-title="{{ item_state["class.template"]["title"] }}"/>
       </ac:link>
     </ac:parameter>
   </ac:structured-macro>
 </p>
+{% endif %}
 
-<h2>API Documentation</h2>
+<h2>Notes about this specific device {{ device_name }}</h2>
 
-<p>Additional usage information about this device may be available on the
-  <a href="https://pcdshub.github.io/pcdsdevices/master/search.html?q={{device_class}}" target="_blank">
-    pcdsdevices documentation site.
-  </a>
+<p>
+  →
+  Please
+  <b>
+    <ac:link>
+      <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}"/>
+      <ac:plain-text-link-body><![CDATA[EDIT NOTES FOR THIS SPECIFIC DEVICE HERE]]></ac:plain-text-link-body>
+    </ac:link>
+  </b>
+  ←
+</p>
+
+<p>
+  <ac:structured-macro ac:name="include" ac:schema-version="1">
+    <ac:parameter ac:name="">
+      <ac:link>
+        <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}"/>
+      </ac:link>
+    </ac:parameter>
+  </ac:structured-macro>
 </p>
 
 <h2>Happi Information</h2>
@@ -112,18 +165,30 @@ The following Jira tickets may be relevant for {{ device_name }}:
 <h2>How do I change this?</h2>
 
 <p>
-  This page is not intended to be modified and will be overwritten without notice.
+  This page is not intended to be modified and <b>will be overwritten without notice</b>.
   However, the notes page is free for you to edit and add notes about {{ device_name }}.
   Those notes will be automatically included in the device information page.
 </p>
 
-<p>If you have something to add of use to others regarding this device, please edit
+<p>
+  If you have something to add of use to others regarding this specific device, please edit
   <ac:link>
-    <ri:page ri:content-title="{{ page_title_prefix }}{{ device_name }}{{ user_page_suffix }}"/>
+    <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}"/>
     <ac:plain-text-link-body><![CDATA[this page]]></ac:plain-text-link-body>
   </ac:link>
   .
 </p>
+
+{% if "class.template" in item_state %}
+<p>
+  You may also edit the class page {{ device_class }} to document information
+  for all similar instances.
+  <a href="/pages/editpage.action?pageId={{ class_template["id"] }}">
+    Click here to edit the class page.
+  </a>
+</p>
+{% endif %}
+
 <p>
   If you find an issue with the data in the happi database, please contact your POC
   or reach out to #pcds-help on Slack.

--- a/device.template
+++ b/device.template
@@ -16,7 +16,7 @@ for all instances.
 ** WAIT! **
 
 -->]]>
-</ac:plain-text-body>
+  </ac:plain-text-body>
 </ac:structured-macro>
 
 <h1>Table of Contents</h1>
@@ -89,7 +89,7 @@ for all instances.
   </ac:structured-macro>
 </p>
 
-<h2>Happi Information</h2>
+<h3>Happi Information</h3>
 
 This information is stored in the happi database.  It is used to create this Python device.
 
@@ -113,7 +113,7 @@ This information is stored in the happi database.  It is used to create this Pyt
     </table>
 
 {% if relevant_pvs_by_kind %}
-  <h2>Relevant PVs</h2>
+  <h3>Relevant PVs</h3>
 
   These PVs are used by the device.  PVs may be recorded in the EPICS Archive Appliance.
   Click any PV to see its history according to the archiver.

--- a/docstring.template
+++ b/docstring.template
@@ -1,7 +1,11 @@
 # title: {{ happi_item.name }} docstring
 {%- for section, section_items in sections.items() %}
     {%- if section_items %}
-        <h3>{{ section }}</h3>
+        {% if section == "Parameters" %}
+          <h3>Python class initialization parameters</h3>
+        {% elif section != "Summary" and section != "Extended Summary" %}
+          <h3>{{ section }}</h3>
+        {% endif %}
         {%- if section == "Parameters" or section == "Attributes" %}
             <table>
                 <thead>

--- a/generate.py
+++ b/generate.py
@@ -666,7 +666,10 @@ def render_device_pages(
         happi_info = json.load(fp)
 
     # Keys for the happi plugin are the happi item names
-    for happi_name, happi_item in happi_info["metadata_by_key"].items():
+    md_by_key = happi_info["metadata_by_key"]
+    for idx, (happi_name, happi_item) in enumerate(md_by_key.items(), 1):
+        logger.info("")
+        logger.info(f"Working on device {idx} of {len(md_by_key)}: {happi_name}...")
         if not happi_item.get("device_class", None):
             continue
 
@@ -698,7 +701,7 @@ def render_device_pages(
         )
         state[happi_name]["happi_item"] = happi_item
 
-        if testing:
+        if testing and idx > 10:
             break
 
     return state
@@ -741,10 +744,7 @@ def render_view_pages(space: str, client: Confluence, root_page, state):
 def main(space: str, root_title: str, testing: bool = False):
     client, root_page = initialize_client(space=space, root_title=root_title)
     all_item_state = render_device_pages(space=space, client=client, root_page=root_page, testing=testing)
-    if testing:
-        view_state = None
-    else:
-        view_state = render_view_pages(space=space, client=client, root_page=root_page, state=all_item_state)
+    view_state = render_view_pages(space=space, client=client, root_page=root_page, state=all_item_state)
     return all_item_state, view_state
 
 

--- a/generate.py
+++ b/generate.py
@@ -634,9 +634,10 @@ def render_device_pages(
         happi_info = json.load(fp)
 
     # Keys for the happi plugin are the happi item names
-    for idx, (happi_name, happi_item) in enumerate(
-        happi_info["metadata_by_key"].items()
-    ):
+    for happi_name, happi_item in happi_info["metadata_by_key"].items():
+        if not happi_item.get("device_class", None):
+            continue
+
         render_kw = get_per_item_render_kwargs(
             client, happi_name, happi_item, state=state
         )

--- a/user.template
+++ b/user.template
@@ -2,10 +2,6 @@
 # title: {{ device_name }}{{ user_page_suffix }}{{ page_title_marker }}
 # label: auto-generated
 # label: no-overwrite
-<p>
-  <ac:structured-macro ac:name="toc" ac:schema-version="1"/>
-</p>
-
 {% for page in related_pages %}
     <h2>Confluence page: {{ page.content.title | e }}</h2>
     <ac:structured-macro ac:name="include" ac:schema-version="1">


### PR DESCRIPTION
Closes #10 by including table of contents on each device page
Closes #11 by linking directly to page IDs with `<a>` instead of confluence macros
Closes Jira ticket https://jira.slac.stanford.edu/browse/LCLSPC-647 by changing docs in a way that seem good to me since feedback was lacking


TODO: don't let me forget:
- [x] Mark class pages as no-overwrite