### PR TITLE
MNT/FIX: fix up documentation generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GENERATE_ARGS ?=
 all: prod-pages
 
 clean:
-	rm -f happi_info.json
+	rm -f happi_info.json .happi_info.json
 
 check:
 	if [[ -f happi_info.json && $$(stat --format="%s" happi_info.json ) -eq 0 ]]; then \
@@ -12,7 +12,11 @@ check:
 	fi \
 
 happi_info.json: /cds/group/pcds/pyps/apps/hutch-python/device_config/db.json
-	python -m whatrecord.plugins.happi > ".${@}"
+	/bin/bash -c " \
+		rm -f ".${@}" && \
+			source /reg/g/pcds/engineering_tools/latest-released/scripts/pcds_conda && \
+			python -m whatrecord.plugins.happi > ".${@}" \
+	"
 	mv ".${@}" "$@"
 
 prod-pages: check happi_info.json

--- a/device.template
+++ b/device.template
@@ -35,7 +35,7 @@ for all instances.
   </i>
 </p>
 
-<br/>
+<br />
 
 <div title="Python documentation string from pcdsdevices">
 {{ device_class_doc }}
@@ -46,19 +46,19 @@ for all instances.
 
 <h2>Notes from the class page</h2>
 <p>
-  →
+  &rarr;
   Please
   <a href="/pages/editpage.action?pageId={{ class_template["id"] }}">
     <b>EDIT CLASS INFORMATION HERE</b>
   </a>
-  ←
+  &larr;
 </p>
 
 <p>
   <ac:structured-macro ac:name="include" ac:schema-version="1">
     <ac:parameter ac:name="">
       <ac:link>
-        <ri:page ri:content-title="{{ item_state["class.template"]["title"] }}"/>
+        <ri:page ri:content-title="{{ item_state["class.template"]["title"] }}" />
       </ac:link>
     </ac:parameter>
   </ac:structured-macro>
@@ -68,22 +68,22 @@ for all instances.
 <h2>Notes about this specific device {{ device_name }}</h2>
 
 <p>
-  →
+  &rarr;
   Please
   <b>
     <ac:link>
-      <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}"/>
+      <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}" />
       <ac:plain-text-link-body><![CDATA[EDIT NOTES FOR THIS SPECIFIC DEVICE HERE]]></ac:plain-text-link-body>
     </ac:link>
   </b>
-  ←
+  &larr;
 </p>
 
 <p>
   <ac:structured-macro ac:name="include" ac:schema-version="1">
     <ac:parameter ac:name="">
       <ac:link>
-        <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}"/>
+        <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}" />
       </ac:link>
     </ac:parameter>
   </ac:structured-macro>
@@ -174,7 +174,7 @@ The following Jira tickets may be relevant for {{ device_name }}:
 <p>
   If you have something to add of use to others regarding this specific device, please edit
   <ac:link>
-    <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}"/>
+    <ri:page ri:content-title="{{ device_name }}{{ user_page_suffix }}" />
     <ac:plain-text-link-body><![CDATA[this page]]></ac:plain-text-link-body>
   </ac:link>
   .

--- a/device.template
+++ b/device.template
@@ -104,8 +104,8 @@ This information is stored in the happi database.  It is used to create this Pyt
 {% for key, value in happi_item.items() %}
     {% if key not in ("_whatrecord", ) and value %}
             <tr>
-                <td>{{ key | e }}</td>
-                <td>{{ value | e | replace("&#39;", "'") }}</td>
+                <td>{{ key | confluence_escape }}</td>
+                <td>{{ value | confluence_escape }}</td>
             </tr>
     {% endif %}
 {% endfor %}

--- a/device.template
+++ b/device.template
@@ -105,7 +105,7 @@ This information is stored in the happi database.  It is used to create this Pyt
     {% if key not in ("_whatrecord", ) and value %}
             <tr>
                 <td>{{ key | e }}</td>
-                <td>{{ value | e }}</td>
+                <td>{{ value | e | replace("&#39;", "'") }}</td>
             </tr>
     {% endif %}
 {% endfor %}

--- a/generate.py
+++ b/generate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import difflib
+import html
 import inspect
 import json
 import logging
@@ -48,6 +49,24 @@ PageHierarchy = dict
 # ]
 
 
+def confluence_escape(value: Optional[str]) -> str:
+    """Escape ``value`` in a way that Confluence won't rewrite it."""
+    if value is None:
+        return ""
+
+    escaped = str(jinja2.filters.escape(value))
+    # Double quotes are not escaped:
+    escaped = escaped.replace("&quot;", '"')
+    # Single quotes are not escaped:
+    escaped = escaped.replace("&#39;", "'")
+    return escaped
+
+
+JINJA_FILTERS = [
+    confluence_escape,
+]
+
+
 class NamedTemplate:
     """
     A jinja template that contains a title and some additional information.
@@ -73,6 +92,8 @@ class NamedTemplate:
         self.labels = list(sorted(set(info["labels"]) | {HAPPI_TO_CONFLUENCE_LABEL}))
         self.titles = [jinja2.Template(title) for title in info["title_lines"]]
         self.template = jinja2.Template(contents)
+        for func in JINJA_FILTERS:
+            self.template.environment.filters[func.__name__] = func
 
         if not self.titles:
             raise ValueError(f"Template invalid: {fn} has no filename lines")
@@ -419,6 +440,15 @@ def check_diff(
     if existing_source == new_source:
         return True
 
+    try:
+        # Unescape both or none
+        (existing_source, new_source) = (
+            html.unescape(existing_source),
+            html.unescape(new_source),
+        )
+    except Exception:
+        ...
+
     for line in page_diff.splitlines():
         if line.startswith("! "):
             line = line.lstrip("!").strip()
@@ -439,13 +469,17 @@ def check_diff(
                 if not DIFF_IGNORE_CONFLUENCE_TAGS:
                     logger.info("Difference found in confluence tag line: %s", line)
                     return False
+            elif not line:
+                # Blank line
+                ...
             else:
                 logger.info("Difference found in line: %s", line)
                 return False
         elif line.startswith("+ ") or line.startswith("- "):
             line = line.lstrip("+- \t").strip()
-            # Look for non-white-space changes
-            if line.strip():
+            if not line:
+                ...
+            else:
                 logger.info("Non-whitespace changes found; pages differ: %s", line)
                 return False
 
@@ -537,6 +571,7 @@ def render_pages(
         options = children.get("_options", {})
         titles, new_source = page_template.render(**render_kw)
         existing_page = None
+        existing_labels = {}
         for title in titles:
             existing_page: Optional[dict] = client.get_page_by_title(
                 title=title,
@@ -544,15 +579,15 @@ def render_pages(
                 expand="body.storage",
             )
             if existing_page:
-                labels = get_page_labels(client, existing_page["id"])
-                if HAPPI_TO_CONFLUENCE_LABEL in labels:
+                existing_labels = get_page_labels(client, existing_page["id"])
+                if HAPPI_TO_CONFLUENCE_LABEL in existing_labels:
                     # OK, even if it exists, this is our page
                     logger.info("Found a page we previously generated: %s (%s)",
-                                title, list(labels))
+                                title, list(existing_labels))
                     break
             if not existing_page:
                 logger.error("Available title: %s", title)
-                labels = {}
+                existing_labels = {}
                 break
         else:
             logger.error("No available titles? %s", titles)
@@ -560,7 +595,7 @@ def render_pages(
 
         do_not_overwrite = not (
             options.get("overwrite", True) and
-            NO_OVERWRITE_LABEL not in labels
+            NO_OVERWRITE_LABEL not in existing_labels
         )
         if do_not_overwrite and existing_page:
             page_info = existing_page
@@ -584,7 +619,7 @@ def render_pages(
                 )
 
             if existing_page and check_diff(existing_source, new_source, page_diff):
-                print("Existing page is up-to-date. Great!")
+                logger.info("Existing page for %r is up-to-date. Great!", title)
                 page_info = existing_page
             else:
                 if existing_page and existing_page["id"] == parent_id:
@@ -608,8 +643,12 @@ def render_pages(
 
                     continue
 
+        page_id: int = page_info["id"]
+
         for label in page_template.labels:
-            client.set_page_label(page_info["id"], label)
+            if label not in existing_labels:
+                logger.info("Setting new label for page %r (%s): %s", title, page_id, label)
+                client.set_page_label(page_id, label)
 
         # for key, value in properties.items():
         #     # client.set_page_property(

--- a/generate.py
+++ b/generate.py
@@ -431,13 +431,16 @@ def check_diff(
             )
             if ac_like:
                 if not DIFF_IGNORE_CONFLUENCE_TAGS:
+                    logger.info("Difference found in confluence tag line: %s", line)
                     return False
             else:
+                logger.info("Difference found in line: %s", line)
                 return False
         elif line.startswith("+ ") or line.startswith("- "):
             line = line.lstrip("+- \t").strip()
-            # White-space changes are bad
+            # Look for non-white-space changes
             if line.strip():
+                logger.info("Non-whitespace changes found; pages differ: %s", line)
                 return False
 
     return True

--- a/generate.py
+++ b/generate.py
@@ -425,8 +425,14 @@ def check_diff(
             # <ac:..> confluence tags may be ignored
             ac_like = any(
                 (
+                    # Confluence "ac" tags - guessing "atlassian confluence":
                     line.startswith("<ac:"),
                     line.startswith("</ac:"),
+                    # Confluence "resource identifier" tags:
+                    line.startswith("<ri:"),
+                    line.startswith("</ri:"),
+                    # TODO: specific to our source, false matches would be bad
+                    line.startswith("-->]]>"),
                 )
             )
             if ac_like:


### PR DESCRIPTION
* Fix up cron job script to ensure it works in a shell without pcds_conda already sourced
* Reduce unnecessary page updates
   * Looks like there are still some escaped html differences that get in the way: quotes may still be getting in the way
   * See `/cds/home/k/klauer/Repos/happi-to-confluence/cron_update_log.txt` for details
   * 8 pages re-generated out of around an estimated 1800 pages currently should be rewritten nightly