### PR TITLE
MAINT: change paths in cron update script

### DIFF
--- a/cron_update.sh
+++ b/cron_update.sh
@@ -2,11 +2,11 @@
 
 set -e -o pipefail
 
-cd /cds/home/k/klauer/Repos/happi-to-confluence
+cd /cds/group/pcds/shared_cron/happi-to-confluence
 
 update() {
   echo "* Updating at $(date)"
-  source /reg/g/pcds/engineering_tools/latest-released/scripts/pcds_conda "" || echo "Sourcing failed?"
+  source /cds/group/pcds/engineering_tools/latest-released/scripts/pcds_conda "" || echo "Sourcing failed?"
   echo "* Environment sourced; working directory:"
   pwd
   echo "* Making pages..."


### PR DESCRIPTION
One more cron script spot where klauer's home directory is present
Simply change it to the new central location